### PR TITLE
Add retrieval, fact-checking, scenarios, and Anthropic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Deep-Research-Reporter
 
 一个最小可运行的管线系统，用于从题目生成**结构化的高质量分析报告**，基于大语言模型（LLM）。  
-该 MVP 聚焦 **Closed-Book 模式**（不依赖外部检索），适合初赛，重点在结构、覆盖度、推理与字数控制。后续可扩展为 **Open-Book**（支持检索、事实校验、情景预测）。
+当前版本已同时支持 **Closed-Book**（纯模型生成）与 **Open-Book**（检索增强、事实校验、情景预测）两种模式。
 
 ---
 
@@ -10,6 +10,9 @@
 - **字数控制**：控制在目标字数 ±10%
 - **固定报告框架**：Title、Abstract、Key Takeaways、Body、Risks、Conclusion
 - **自检机制**：基于 LLM 的编辑回路，提升逻辑清晰度与可读性
+- **Open-Book 检索**：调用 Wikipedia 摘要获取背景信息
+- **事实校验与情景预测**：对生成内容做主张-证据核查，并给出趋势判断
+- **多模型支持**：OpenAI、Gemini、DeepSeek、ChatGLM、Anthropic 等主流 LLM
 - **CLI 一键生成**：命令行直接生成 Markdown 格式的报告
 
 ---
@@ -20,12 +23,15 @@ python -m venv .venv && source .venv/bin/activate   # Windows: .venv\Scripts\act
 pip install -r requirements.txt
 ````
 
-配置 LLM API Key（默认使用 OpenAI）：
+配置 LLM API Key（根据所选 provider）：
 
 ```bash
-export OPENAI_API_KEY=sk-xxxx
-# 或者在项目根目录创建 .env 文件，内容如下：
-# OPENAI_API_KEY=sk-xxxx
+export OPENAI_API_KEY=sk-xxxx        # OpenAI
+export GEMINI_API_KEY=sk-xxxx        # Gemini
+export DEEPSEEK_API_KEY=sk-xxxx      # DeepSeek
+export CHATGLM_API_KEY=sk-xxxx       # ChatGLM
+export ANTHROPIC_API_KEY=sk-xxxx     # Anthropic
+# 或在项目根目录创建 .env 文件写入上述变量
 ```
 
 ---
@@ -35,15 +41,17 @@ export OPENAI_API_KEY=sk-xxxx
 在命令行中运行：
 
 ```bash
-python -m drr.cli \
+python -m src.cli \
   --topic "Assess the near-term outlook of grid-scale energy storage" \
-  --words 1000
+  --words 1000 \
+  --provider anthropic \
+  --model claude-3-haiku-20240307
 ```
 
 输出将直接打印在终端，可重定向保存到文件：
 
 ```bash
-python -m drr.cli --topic "..." --words 1200 > report.md
+python -m src.cli --topic "..." --words 1200 -p openai -m gpt-4o-mini > report.md
 ```
 
 ---
@@ -55,12 +63,14 @@ deep-research-reporter/
 ├─ README.md
 ├─ requirements.txt
 ├─ src/
-│  └─ drr/
-│     ├─ __init__.py
-│     ├─ llm.py
-│     ├─ prompts.py
-│     ├─ pipeline.py
-│     └─ cli.py
+│  ├─ __init__.py
+│  ├─ cli.py
+│  ├─ llm.py
+│  ├─ prompts.py
+│  ├─ pipeline.py
+│  ├─ retrieval.py
+│  ├─ factcheck.py
+│  └─ scenarios.py
 └─ examples/
    └─ sample_topic.txt
 ```
@@ -69,15 +79,15 @@ deep-research-reporter/
 
 ## 路线图
 
-* [ ] `retrieval.py` —— 支持 Open-Book 检索增强
-* [ ] `factcheck.py` —— 主张-证据事实校验
-* [ ] `scenarios.py` —— 情景预测与趋势分析（复赛用）
-* [ ] 多模型支持（Anthropic, DeepSeek 等）
+* [x] `retrieval.py` —— 支持 Open-Book 检索增强
+* [x] `factcheck.py` —— 主张-证据事实校验
+* [x] `scenarios.py` —— 情景预测与趋势分析
+* [x] 多模型支持（Anthropic, DeepSeek 等）
+* [ ] 更丰富的检索源与缓存机制
+* [ ] 自动化测试与评估
 
 ---
 
 ## 许可
 
 MIT License
-
-```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ click>=8.1.7
 python-dotenv>=1.0.1
 google-generativeai>=0.7.2
 zhipuai>=2.1.0
+anthropic>=0.26.0
+requests>=2.31.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,17 @@ Modules:
 - llm.py       : Thin wrapper for LLM API calls
 - prompts.py   : Centralized prompt templates
 - pipeline.py  : Core pipeline (intent parsing → outline → writing → critique → compose)
+- retrieval.py : Open-book retrieval utilities
+- factcheck.py : Claim-evidence fact checking
+- scenarios.py : Scenario prediction and trend analysis
 - cli.py       : Command-line entry point
 """
 
-__all__ = ["llm", "prompts", "pipeline"]
+__all__ = [
+    "llm",
+    "prompts",
+    "pipeline",
+    "retrieval",
+    "factcheck",
+    "scenarios",
+]

--- a/src/cli.py
+++ b/src/cli.py
@@ -28,7 +28,7 @@ def _load_topic(topic: str | None, topic_file: str | None) -> str:
 @click.option("--topic-file", "-f", help="Read topic from a text file.")
 @click.option("--words", "-w", required=True, type=int, help="Target word count.")
 @click.option("--provider", "-p",
-              type=click.Choice(["openai", "gemini", "deepseek", "chatglm"], case_sensitive=False),
+              type=click.Choice(["openai", "gemini", "deepseek", "chatglm", "anthropic"], case_sensitive=False),
               default="openai", show_default=True,
               help="LLM provider.")
 @click.option("--model", "-m", default="gpt-4o-mini", show_default=True,

--- a/src/factcheck.py
+++ b/src/factcheck.py
@@ -1,0 +1,32 @@
+"""Simple claim-evidence fact checking using an LLM."""
+from __future__ import annotations
+
+import json
+from typing import Dict
+
+from .llm import LLM
+from . import prompts
+
+
+def check_fact(llm: LLM, claim: str, evidence: str) -> Dict[str, str]:
+    """Return a verdict on whether evidence supports a claim.
+
+    The LLM is asked to respond with a JSON object
+    {"verdict": "SUPPORTED|REFUTED|INSUFFICIENT", "rationale": str}.
+    """
+    payload = f"Claim: {claim}\n\nEvidence:\n{evidence}"
+    messages = [
+        {"role": "system", "content": prompts.SYSTEM_PROMPT},
+        {"role": "user", "content": prompts.FACTCHECK_PROMPT},
+        {"role": "user", "content": payload},
+    ]
+    raw = llm.chat(messages, max_tokens=600, temperature=0.0)
+    try:
+        data = json.loads(raw)
+        verdict = str(data.get("verdict", "INSUFFICIENT")).upper()
+        rationale = str(data.get("rationale", "")).strip()
+        if verdict not in {"SUPPORTED", "REFUTED", "INSUFFICIENT"}:
+            verdict = "INSUFFICIENT"
+        return {"verdict": verdict, "rationale": rationale}
+    except Exception:
+        return {"verdict": "INSUFFICIENT", "rationale": raw.strip()}

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -26,6 +26,7 @@ Input:
 - section_goal
 - key_points (bullet points to cover)
 - target_words (approximate)
+- context (optional background info from retrieval)
 
 Write the section with:
 - a clear topic sentence and tight logical flow
@@ -69,3 +70,14 @@ Preserve key arguments, logic, and readability. Avoid removing headings.
 Return ONLY the adjusted report.
 TARGET_WORDS={target}
 """
+
+
+FACTCHECK_PROMPT = """You are a meticulous fact checker. Given a claim and
+supporting evidence text, decide whether the evidence supports, refutes or is
+insufficient for the claim. Respond with a JSON object {"verdict":
+"SUPPORTED"|"REFUTED"|"INSUFFICIENT", "rationale": "short explanation"}."""
+
+
+SCENARIO_PROMPT = """You are a scenario-planning analyst. From a topic and a
+time horizon, produce a brief trend analysis and 2-3 plausible future
+scenarios. Use clear headings or bullet points."""

--- a/src/retrieval.py
+++ b/src/retrieval.py
@@ -1,0 +1,55 @@
+"""Retrieval utilities for open-book augmentation.
+
+Currently uses Wikipedia open search API to fetch short summaries that can be
+fed into the writing pipeline as background context.
+"""
+from __future__ import annotations
+
+import requests
+from typing import Dict, List
+
+
+def open_book_search(query: str, n_results: int = 3) -> List[Dict[str, str]]:
+    """Return top Wikipedia results with summaries.
+
+    Parameters
+    ----------
+    query: str
+        Search query.
+    n_results: int, default 3
+        Number of top results to fetch.
+    """
+    if not query:
+        return []
+    params = {
+        "action": "opensearch",
+        "search": query,
+        "limit": n_results,
+        "namespace": 0,
+        "format": "json",
+    }
+    try:
+        resp = requests.get(
+            "https://en.wikipedia.org/w/api.php", params=params, timeout=10
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return []
+
+    titles = data[1]
+    urls = data[3]
+    results: List[Dict[str, str]] = []
+    for title, url in zip(titles, urls):
+        summary = ""
+        try:
+            s_resp = requests.get(
+                f"https://en.wikipedia.org/api/rest_v1/page/summary/{title}",
+                timeout=10,
+            )
+            if s_resp.status_code == 200:
+                summary = s_resp.json().get("extract", "")
+        except Exception:
+            summary = ""
+        results.append({"title": title, "url": url, "summary": summary})
+    return results

--- a/src/scenarios.py
+++ b/src/scenarios.py
@@ -1,0 +1,16 @@
+"""Scenario prediction and trend analysis module."""
+from __future__ import annotations
+
+from .llm import LLM
+from . import prompts
+
+
+def generate_scenarios(llm: LLM, topic: str, horizon: str = "5 years") -> str:
+    """Return scenario analysis for a topic and time horizon."""
+    payload = f"Topic: {topic}\nTime horizon: {horizon}"
+    messages = [
+        {"role": "system", "content": prompts.SYSTEM_PROMPT},
+        {"role": "user", "content": prompts.SCENARIO_PROMPT},
+        {"role": "user", "content": payload},
+    ]
+    return llm.chat(messages, max_tokens=1200)


### PR DESCRIPTION
## Summary
- add open-book Wikipedia retrieval utilities and integrate context into section writing
- introduce fact-check and scenario analysis helpers
- extend LLM wrapper with Anthropic/Claude provider and expose via CLI
- document new modules, usage, API keys, and roadmap in README

## Testing
- `python -m py_compile src/*.py`
- `python - <<'PY'
import sys
sys.path.append('src')
import retrieval
print(retrieval.open_book_search('artificial intelligence', n_results=1))
PY`
- `python -m src.cli --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68a7ff68f40883338f072f923790e8f9