### PR TITLE
feat: cache Wikipedia search results and polish report transitions

### DIFF
--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -126,6 +126,16 @@ def compose_report(llm: LLM, sections: List[Tuple[str, str]], target_words: int)
     return llm.chat(messages, max_tokens=3500)
 
 
+def polish_report(llm: LLM, report: str) -> str:
+    """Refine the full report for smoother transitions and clarity."""
+    messages = [
+        {"role": "system", "content": prompts.SYSTEM_PROMPT},
+        {"role": "user", "content": prompts.POLISH_PROMPT},
+        {"role": "user", "content": report},
+    ]
+    return llm.chat(messages, max_tokens=3500)
+
+
 def enforce_wordcount(llm: LLM, report: str, target_words: int) -> str:
     messages = [
         {"role": "system", "content": prompts.SYSTEM_PROMPT},
@@ -168,7 +178,8 @@ def generate_report_v2(
         sections_out.append((sec.get("title", "Section"), text2))
 
     composed = compose_report(llm, sections_out, intent["word_limit"])
-    final = enforce_wordcount(llm, composed, intent["word_limit"])
+    polished = polish_report(llm, composed)
+    final = enforce_wordcount(llm, polished, intent["word_limit"])
     return final
 
 

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -72,6 +72,12 @@ TARGET_WORDS={target}
 """
 
 
+POLISH_PROMPT = """Polish the full draft for smoother transitions, flow, and clarity.
+Fix minor grammar issues and ensure the report reads as a cohesive whole.
+Return ONLY the refined report text.
+"""
+
+
 FACTCHECK_PROMPT = """You are a meticulous fact checker. Given a claim and
 supporting evidence text, decide whether the evidence supports, refutes or is
 insufficient for the claim. Respond with a JSON object {"verdict":

--- a/src/retrieval.py
+++ b/src/retrieval.py
@@ -5,22 +5,22 @@ fed into the writing pipeline as background context.
 """
 from __future__ import annotations
 
+import copy
+from functools import lru_cache
 import requests
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
+@lru_cache(maxsize=128)
+def _open_book_search_cached(query: str, n_results: int) -> Tuple[Dict[str, str], ...]:
+    """Cached helper for ``open_book_search``.
 
-def open_book_search(query: str, n_results: int = 3) -> List[Dict[str, str]]:
-    """Return top Wikipedia results with summaries.
-
-    Parameters
-    ----------
-    query: str
-        Search query.
-    n_results: int, default 3
-        Number of top results to fetch.
+    The function contacts the Wikipedia API and stores results in an LRU cache
+    to avoid repeated network calls when the same query is requested multiple
+    times within a single run. The returned tuple is treated as immutable to
+    make it safe for caching.
     """
     if not query:
-        return []
+        return tuple()
     params = {
         "action": "opensearch",
         "search": query,
@@ -35,7 +35,7 @@ def open_book_search(query: str, n_results: int = 3) -> List[Dict[str, str]]:
         resp.raise_for_status()
         data = resp.json()
     except Exception:
-        return []
+        return tuple()
 
     titles = data[1]
     urls = data[3]
@@ -52,4 +52,21 @@ def open_book_search(query: str, n_results: int = 3) -> List[Dict[str, str]]:
         except Exception:
             summary = ""
         results.append({"title": title, "url": url, "summary": summary})
-    return results
+    return tuple(results)
+
+
+def open_book_search(query: str, n_results: int = 3) -> List[Dict[str, str]]:
+    """Return top Wikipedia results with summaries.
+
+    Results are cached in-memory for the duration of the process so repeated
+    calls with the same arguments do not hit the network again.
+
+    Parameters
+    ----------
+    query: str
+        Search query.
+    n_results: int, default 3
+        Number of top results to fetch.
+    """
+    # ``copy`` ensures callers don't mutate the cached objects.
+    return [copy.deepcopy(r) for r in _open_book_search_cached(query, n_results)]


### PR DESCRIPTION
## Summary
- cache Wikipedia open-book search results in memory using an LRU strategy
- avoid repeated requests by returning copies of cached results
- refine composed reports with a polishing pass to improve section transitions

## Testing
- `python -m py_compile src/pipeline.py src/prompts.py`
- `python - <<'PY'
from src.pipeline import polish_report
class DummyLLM:
    def chat(self, messages, max_tokens=None, temperature=None):
        return messages[-1]['content'].upper()
print(polish_report(DummyLLM(), "Intro.\n\nDetails."))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68af1bf94d2083339ff5e939e0b775b2